### PR TITLE
Streamline API versioning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,9 @@
 
 # Base image
 FROM    python:3 AS base
-
 ENV     STREAMLIT_BROWSER_GATHER_USAGE_STATS=false
-
 WORKDIR /app
-
+CMD     ["./api.py"]
 RUN     pip install --no-cache-dir \
             altair \
             "elasticsearch>=7.0.0,<8.0.0" \
@@ -20,19 +18,16 @@ RUN     pip install --no-cache-dir \
             wordcloud \
             pyyaml
 
-COPY    . ./
-
 # Lint code
 FROM    base
-
 RUN     pip install --no-cache-dir pylint
+COPY    . ./
 RUN     pylint *.py \
             --max-line-length=120 \
             --good-names="c,ct,e,ep,id,q,r" \
-            --disable="C0114,C0115,C0116" \
+            --disable="C0103,C0114,C0115,C0116" \
             --extension-pkg-whitelist="pydantic"
 
 # Build image
 FROM    base
-
-CMD     ["./api.py"]
+COPY    . ./


### PR DESCRIPTION
Fixes #3

* Added `x-api-version` header to report the SemVer of the API
* Exposed this new header in CORS headers
* The path scope is still using just the major version like `v1`
* Changed the constant `VERSION_1` to an `Enum` so multiple major versions can be served at the same time when breaking changes are introduced
* Improved layer cache utilization in `Dockerfile`
