### PR TITLE
Fix docker-compose error

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,4 @@
+version: '3'
 services:
   api:
     image: colsearch


### PR DESCRIPTION
Using `docker-compose version 1.25.0, build unknown` in Ubuntu Focal, when I try to run:
```
docker-compose up
```
I get the following error:
```
ERROR: The Compose file './docker-compose.yml' is invalid because:
Unsupported config option for services: 'ui'
```

This conf addition fixes it.