### PR TITLE
/article/id URL param must be a `path`

### DIFF
--- a/api.py
+++ b/api.py
@@ -433,8 +433,8 @@ def get_terms_via_payload(collection: Collection, payload: Query, field: TermFie
     return _get_terms(collection, payload.q, field.value, aggr.value)
 
 
-@v1.get("/{collection}/article/{id}", tags=["data"])
-@v1.head("/{collection}/article/{id}", include_in_schema=False)
+@v1.get("/{collection}/article/{id:path}", tags=["data"])
+@v1.head("/{collection}/article/{id:path}", include_in_schema=False)
 def get_article(collection: Collection, id: str, req: Request):  # pylint: disable=redefined-builtin
     """
     Fetch an individual article record by ID


### PR DESCRIPTION
When a URL parameter is defined as `string` and it contains `/`, then the web API is confused and it considers it as multiple params.

You need to define it as `id:path`

Ref: https://fastapi.tiangolo.com/tutorial/path-params/#path-convertor

Also note that when a URL param is a `path`, it must be the last one in the URL for obvious reasons.